### PR TITLE
0.3.0-alpha.2 - Serializers

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,24 +2,25 @@
 
 ---
 
-### Adding as a dependency
+### Adding as a dependency (Gradle)
+
+First, add the Bladehunt maven repo to the repositories
 
 ```kotlin
 repositories {
     maven("https://mvn.bladehunt.net/releases")
 }
-
-dependencies {
-    implementation("net.bladehunt:kotstom:0.3.0-alpha.1")
-
-    // If you need Adventure NBT kotlinx.serialization support
-    implementation("net.bladehunt:kotstom-adventure-serialization:0.3.0-alpha.1")
-}
 ```
+
+The latest version can be found [here](https://mvn.bladehunt.net/#/releases/net/bladehunt/kotstom).
 
 ## Module Overview
 
 ### KotStom
+
+```kotlin
+implementation("net.bladehunt:kotstom:<version>")
+```
 
 - Minestom Extensions
     - Tag delegates (`by Tag`)
@@ -45,11 +46,46 @@ dependencies {
 
 ### adventure-serialization
 
+```kotlin
+implementation("net.bladehunt:kotstom-adventure-serialization:<version>")
+```
+
 This module contains an Adventure NBT encoder and decoder.
 
 - Supports polymorphism
 - Supports collections
 - Usage: `AdventureNbt.encodeToCompound`, `AdventureNbt.decodeFromCompound`
     - Initializing your own instance of `AdventureNbt` can be done using `AdventureNbt`'s constructor
+
+### serialization
+
+```kotlin
+implementation("net.bladehunt:kotstom-serialization:<version>")
+```
+
+This module contains some kotlinx.serialization serializers for Minestom.
+
+- Adventure
+    - MiniMessage Serializer
+- StaticProtocolObject
+    - Material serializer
+    - EntityType serializer
+    - PotionEffect serializer
+    - Namespace serializer
+- Point
+    - Supports non-content based serialization (Needs a `type` field)
+    - Serial names are the simple names
+    - BlockVecSerializer
+    - PosSerializer
+    - VecSerializer
+- UUID
+    - StringUuidSerializer (Serializes to string)
+    - UuidSerializer (Serializes to most significant/least significant bits)
+- Module
+    - Note: MiniMessageSerializer is not included in these modules
+    - MinestomModule
+        - Prefers serializers such as UuidSerializer
+    - MinestomConfigModule
+        - Prefers more human readable serializers
 
 ### For more information, visit [the wiki](https://www.bladehunt.net/developers/kotstom) or view [the example](example/src/main/kotlin)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 kotlin.code.style=official
 name=kotstom
 group=net.bladehunt
-version=0.3.0-alpha.1
+version=0.3.0-alpha.2

--- a/serialization/build.gradle.kts
+++ b/serialization/build.gradle.kts
@@ -1,0 +1,35 @@
+plugins { kotlin("plugin.serialization") version "2.0.0" }
+
+repositories { mavenCentral() }
+
+dependencies {
+    compileOnly(libs.minestom)
+    compileOnly(libs.kotlinx.serialization.core)
+
+    testImplementation(libs.minestom)
+    testImplementation(libs.bundles.test)
+}
+
+tasks.test { useJUnitPlatform() }
+
+java { withSourcesJar() }
+
+publishing {
+    publications {
+        create<MavenPublication>("library") {
+            from(components["java"])
+            artifactId = "kotstom-serialization"
+        }
+    }
+    repositories {
+        maven {
+            name = "releases"
+            url = uri("https://mvn.bladehunt.net/releases")
+            credentials(PasswordCredentials::class) {
+                username = System.getenv("MAVEN_NAME")
+                password = System.getenv("MAVEN_SECRET")
+            }
+            authentication { create<BasicAuthentication>("basic") }
+        }
+    }
+}

--- a/serialization/build.gradle.kts
+++ b/serialization/build.gradle.kts
@@ -5,8 +5,10 @@ repositories { mavenCentral() }
 dependencies {
     compileOnly(libs.minestom)
     compileOnly(libs.kotlinx.serialization.core)
+    compileOnly(libs.adventure.minimessage)
 
     testImplementation(libs.minestom)
+    testImplementation(libs.kotlinx.serialization.json)
     testImplementation(libs.bundles.test)
 }
 

--- a/serialization/src/main/kotlin/net/bladehunt/kotstom/serialization/MinestomConfigModule.kt
+++ b/serialization/src/main/kotlin/net/bladehunt/kotstom/serialization/MinestomConfigModule.kt
@@ -1,0 +1,3 @@
+package net.bladehunt.kotstom.serialization
+
+class MinestomConfigModule {}

--- a/serialization/src/main/kotlin/net/bladehunt/kotstom/serialization/MinestomConfigModule.kt
+++ b/serialization/src/main/kotlin/net/bladehunt/kotstom/serialization/MinestomConfigModule.kt
@@ -1,3 +1,0 @@
-package net.bladehunt.kotstom.serialization
-
-class MinestomConfigModule {}

--- a/serialization/src/main/kotlin/net/bladehunt/kotstom/serialization/MinestomModule.kt
+++ b/serialization/src/main/kotlin/net/bladehunt/kotstom/serialization/MinestomModule.kt
@@ -1,0 +1,29 @@
+package net.bladehunt.kotstom.serialization
+
+import java.util.*
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.polymorphic
+import net.bladehunt.kotstom.serialization.namespace.MaterialSerializer
+import net.bladehunt.kotstom.serialization.namespace.NamespaceSerializer
+import net.bladehunt.kotstom.serialization.point.BlockVecSerializer
+import net.bladehunt.kotstom.serialization.point.PosSerializer
+import net.bladehunt.kotstom.serialization.point.VecSerializer
+import net.bladehunt.kotstom.serialization.uuid.UuidSerializer
+import net.minestom.server.coordinate.BlockVec
+import net.minestom.server.coordinate.Point
+import net.minestom.server.coordinate.Pos
+import net.minestom.server.coordinate.Vec
+import net.minestom.server.item.Material
+import net.minestom.server.utils.NamespaceID
+
+val minestomModule = SerializersModule {
+    polymorphic(Point::class) {
+        subclass(BlockVec::class, BlockVecSerializer)
+        subclass(Pos::class, PosSerializer)
+        subclass(Vec::class, VecSerializer)
+    }
+
+    contextual(NamespaceID::class, NamespaceSerializer)
+    contextual(Material::class, MaterialSerializer)
+    contextual(UUID::class, UuidSerializer)
+}

--- a/serialization/src/main/kotlin/net/bladehunt/kotstom/serialization/MinestomModule.kt
+++ b/serialization/src/main/kotlin/net/bladehunt/kotstom/serialization/MinestomModule.kt
@@ -1,6 +1,5 @@
 package net.bladehunt.kotstom.serialization
 
-import java.util.*
 import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.SerializersModuleBuilder
 import kotlinx.serialization.modules.polymorphic
@@ -21,6 +20,7 @@ import net.minestom.server.entity.EntityType
 import net.minestom.server.item.Material
 import net.minestom.server.potion.PotionEffect
 import net.minestom.server.utils.NamespaceID
+import java.util.*
 
 internal fun SerializersModuleBuilder.registerDefaultModules() {
     polymorphic(Point::class) {
@@ -28,6 +28,10 @@ internal fun SerializersModuleBuilder.registerDefaultModules() {
         subclass(Pos::class, PosSerializer)
         subclass(Vec::class, VecSerializer)
     }
+
+    contextual(BlockVec::class, BlockVecSerializer)
+    contextual(Pos::class, PosSerializer)
+    contextual(Vec::class, VecSerializer)
 
     contextual(NamespaceID::class, NamespaceSerializer)
     contextual(Material::class, MaterialSerializer)

--- a/serialization/src/main/kotlin/net/bladehunt/kotstom/serialization/MinestomModule.kt
+++ b/serialization/src/main/kotlin/net/bladehunt/kotstom/serialization/MinestomModule.kt
@@ -2,21 +2,27 @@ package net.bladehunt.kotstom.serialization
 
 import java.util.*
 import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.SerializersModuleBuilder
 import kotlinx.serialization.modules.polymorphic
+import net.bladehunt.kotstom.serialization.namespace.EntityTypeSerializer
 import net.bladehunt.kotstom.serialization.namespace.MaterialSerializer
 import net.bladehunt.kotstom.serialization.namespace.NamespaceSerializer
+import net.bladehunt.kotstom.serialization.namespace.PotionEffectSerializer
 import net.bladehunt.kotstom.serialization.point.BlockVecSerializer
 import net.bladehunt.kotstom.serialization.point.PosSerializer
 import net.bladehunt.kotstom.serialization.point.VecSerializer
+import net.bladehunt.kotstom.serialization.uuid.StringUuidSerializer
 import net.bladehunt.kotstom.serialization.uuid.UuidSerializer
 import net.minestom.server.coordinate.BlockVec
 import net.minestom.server.coordinate.Point
 import net.minestom.server.coordinate.Pos
 import net.minestom.server.coordinate.Vec
+import net.minestom.server.entity.EntityType
 import net.minestom.server.item.Material
+import net.minestom.server.potion.PotionEffect
 import net.minestom.server.utils.NamespaceID
 
-val minestomModule = SerializersModule {
+internal fun SerializersModuleBuilder.registerDefaultModules() {
     polymorphic(Point::class) {
         subclass(BlockVec::class, BlockVecSerializer)
         subclass(Pos::class, PosSerializer)
@@ -25,5 +31,18 @@ val minestomModule = SerializersModule {
 
     contextual(NamespaceID::class, NamespaceSerializer)
     contextual(Material::class, MaterialSerializer)
+    contextual(EntityType::class, EntityTypeSerializer)
+    contextual(PotionEffect::class, PotionEffectSerializer)
+}
+
+val MinestomConfigModule = SerializersModule {
+    registerDefaultModules()
+
+    contextual(UUID::class, StringUuidSerializer)
+}
+
+val MinestomModule = SerializersModule {
+    registerDefaultModules()
+
     contextual(UUID::class, UuidSerializer)
 }

--- a/serialization/src/main/kotlin/net/bladehunt/kotstom/serialization/component/MiniMessageSerializer.kt
+++ b/serialization/src/main/kotlin/net/bladehunt/kotstom/serialization/component/MiniMessageSerializer.kt
@@ -1,0 +1,23 @@
+package net.bladehunt.kotstom.serialization.component
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.minimessage.MiniMessage
+
+open class MiniMessageSerializer(val miniMessage: MiniMessage) : KSerializer<Component> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor(Component::class.qualifiedName!!, PrimitiveKind.STRING)
+
+    override fun deserialize(decoder: Decoder): Component =
+        miniMessage.deserialize(decoder.decodeString())
+
+    override fun serialize(encoder: Encoder, value: Component) =
+        encoder.encodeString(miniMessage.serialize(value))
+
+    companion object Default : MiniMessageSerializer(MiniMessage.miniMessage())
+}

--- a/serialization/src/main/kotlin/net/bladehunt/kotstom/serialization/namespace/AbstractProtocolObjectSerializer.kt
+++ b/serialization/src/main/kotlin/net/bladehunt/kotstom/serialization/namespace/AbstractProtocolObjectSerializer.kt
@@ -1,0 +1,23 @@
+package net.bladehunt.kotstom.serialization.namespace
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import net.minestom.server.registry.StaticProtocolObject
+import net.minestom.server.utils.NamespaceID
+
+abstract class AbstractProtocolObjectSerializer<T : StaticProtocolObject>(serialName: String) :
+    KSerializer<T> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor(serialName, PrimitiveKind.STRING)
+
+    protected abstract fun fromNamespaceId(namespaceID: NamespaceID): T?
+
+    final override fun deserialize(decoder: Decoder): T =
+        requireNotNull(fromNamespaceId(NamespaceID.from(decoder.decodeString())))
+
+    final override fun serialize(encoder: Encoder, value: T) = encoder.encodeString(value.name())
+}

--- a/serialization/src/main/kotlin/net/bladehunt/kotstom/serialization/namespace/AbstractProtocolObjectSerializer.kt
+++ b/serialization/src/main/kotlin/net/bladehunt/kotstom/serialization/namespace/AbstractProtocolObjectSerializer.kt
@@ -8,9 +8,13 @@ import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import net.minestom.server.registry.StaticProtocolObject
 import net.minestom.server.utils.NamespaceID
+import kotlin.reflect.KClass
 
 abstract class AbstractProtocolObjectSerializer<T : StaticProtocolObject>(serialName: String) :
     KSerializer<T> {
+
+    constructor(clazz: KClass<T>) : this(requireNotNull(clazz.qualifiedName))
+
     override val descriptor: SerialDescriptor =
         PrimitiveSerialDescriptor(serialName, PrimitiveKind.STRING)
 

--- a/serialization/src/main/kotlin/net/bladehunt/kotstom/serialization/namespace/EntityTypeSerializer.kt
+++ b/serialization/src/main/kotlin/net/bladehunt/kotstom/serialization/namespace/EntityTypeSerializer.kt
@@ -3,7 +3,7 @@ package net.bladehunt.kotstom.serialization.namespace
 import net.minestom.server.entity.EntityType
 import net.minestom.server.utils.NamespaceID
 
-object EntityTypeSerializer : AbstractProtocolObjectSerializer<EntityType>("EntityType") {
+object EntityTypeSerializer : AbstractProtocolObjectSerializer<EntityType>(EntityType::class) {
     override fun fromNamespaceId(namespaceID: NamespaceID): EntityType? =
         EntityType.fromNamespaceId(namespaceID)
 }

--- a/serialization/src/main/kotlin/net/bladehunt/kotstom/serialization/namespace/EntityTypeSerializer.kt
+++ b/serialization/src/main/kotlin/net/bladehunt/kotstom/serialization/namespace/EntityTypeSerializer.kt
@@ -1,0 +1,9 @@
+package net.bladehunt.kotstom.serialization.namespace
+
+import net.minestom.server.entity.EntityType
+import net.minestom.server.utils.NamespaceID
+
+object EntityTypeSerializer : AbstractProtocolObjectSerializer<EntityType>("EntityType") {
+    override fun fromNamespaceId(namespaceID: NamespaceID): EntityType? =
+        EntityType.fromNamespaceId(namespaceID)
+}

--- a/serialization/src/main/kotlin/net/bladehunt/kotstom/serialization/namespace/MaterialSerializer.kt
+++ b/serialization/src/main/kotlin/net/bladehunt/kotstom/serialization/namespace/MaterialSerializer.kt
@@ -1,20 +1,9 @@
 package net.bladehunt.kotstom.serialization.namespace
 
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.descriptors.PrimitiveKind
-import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
-import kotlinx.serialization.descriptors.SerialDescriptor
-import kotlinx.serialization.encoding.Decoder
-import kotlinx.serialization.encoding.Encoder
 import net.minestom.server.item.Material
+import net.minestom.server.utils.NamespaceID
 
-object MaterialSerializer : KSerializer<Material> {
-    override val descriptor: SerialDescriptor =
-        PrimitiveSerialDescriptor("Material", PrimitiveKind.STRING)
-
-    override fun deserialize(decoder: Decoder): Material =
-        requireNotNull(Material.fromNamespaceId(NamespaceSerializer.deserialize(decoder)))
-
-    override fun serialize(encoder: Encoder, value: Material) =
-        NamespaceSerializer.serialize(encoder, value.namespace())
+object MaterialSerializer : AbstractProtocolObjectSerializer<Material>("Material") {
+    override fun fromNamespaceId(namespaceID: NamespaceID): Material? =
+        Material.fromNamespaceId(namespaceID)
 }

--- a/serialization/src/main/kotlin/net/bladehunt/kotstom/serialization/namespace/MaterialSerializer.kt
+++ b/serialization/src/main/kotlin/net/bladehunt/kotstom/serialization/namespace/MaterialSerializer.kt
@@ -1,0 +1,20 @@
+package net.bladehunt.kotstom.serialization.namespace
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import net.minestom.server.item.Material
+
+object MaterialSerializer : KSerializer<Material> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("Material", PrimitiveKind.STRING)
+
+    override fun deserialize(decoder: Decoder): Material =
+        requireNotNull(Material.fromNamespaceId(NamespaceSerializer.deserialize(decoder)))
+
+    override fun serialize(encoder: Encoder, value: Material) =
+        NamespaceSerializer.serialize(encoder, value.namespace())
+}

--- a/serialization/src/main/kotlin/net/bladehunt/kotstom/serialization/namespace/MaterialSerializer.kt
+++ b/serialization/src/main/kotlin/net/bladehunt/kotstom/serialization/namespace/MaterialSerializer.kt
@@ -3,7 +3,7 @@ package net.bladehunt.kotstom.serialization.namespace
 import net.minestom.server.item.Material
 import net.minestom.server.utils.NamespaceID
 
-object MaterialSerializer : AbstractProtocolObjectSerializer<Material>("Material") {
+object MaterialSerializer : AbstractProtocolObjectSerializer<Material>(Material::class) {
     override fun fromNamespaceId(namespaceID: NamespaceID): Material? =
         Material.fromNamespaceId(namespaceID)
 }

--- a/serialization/src/main/kotlin/net/bladehunt/kotstom/serialization/namespace/NamespaceSerializer.kt
+++ b/serialization/src/main/kotlin/net/bladehunt/kotstom/serialization/namespace/NamespaceSerializer.kt
@@ -10,7 +10,7 @@ import net.minestom.server.utils.NamespaceID
 
 object NamespaceSerializer : KSerializer<NamespaceID> {
     override val descriptor: SerialDescriptor =
-        PrimitiveSerialDescriptor("NamespaceID", PrimitiveKind.STRING)
+        PrimitiveSerialDescriptor(NamespaceID::class.qualifiedName!!, PrimitiveKind.STRING)
 
     override fun deserialize(decoder: Decoder): NamespaceID =
         NamespaceID.from(decoder.decodeString())

--- a/serialization/src/main/kotlin/net/bladehunt/kotstom/serialization/namespace/NamespaceSerializer.kt
+++ b/serialization/src/main/kotlin/net/bladehunt/kotstom/serialization/namespace/NamespaceSerializer.kt
@@ -1,0 +1,20 @@
+package net.bladehunt.kotstom.serialization.namespace
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import net.minestom.server.utils.NamespaceID
+
+object NamespaceSerializer : KSerializer<NamespaceID> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("NamespaceID", PrimitiveKind.STRING)
+
+    override fun deserialize(decoder: Decoder): NamespaceID =
+        NamespaceID.from(decoder.decodeString())
+
+    override fun serialize(encoder: Encoder, value: NamespaceID) =
+        encoder.encodeString(value.toString())
+}

--- a/serialization/src/main/kotlin/net/bladehunt/kotstom/serialization/namespace/PotionEffectSerializer.kt
+++ b/serialization/src/main/kotlin/net/bladehunt/kotstom/serialization/namespace/PotionEffectSerializer.kt
@@ -1,0 +1,9 @@
+package net.bladehunt.kotstom.serialization.namespace
+
+import net.minestom.server.potion.PotionEffect
+import net.minestom.server.utils.NamespaceID
+
+object PotionEffectSerializer : AbstractProtocolObjectSerializer<PotionEffect>("PotionEffect") {
+    override fun fromNamespaceId(namespaceID: NamespaceID): PotionEffect? =
+        PotionEffect.fromNamespaceId(namespaceID)
+}

--- a/serialization/src/main/kotlin/net/bladehunt/kotstom/serialization/namespace/PotionEffectSerializer.kt
+++ b/serialization/src/main/kotlin/net/bladehunt/kotstom/serialization/namespace/PotionEffectSerializer.kt
@@ -3,7 +3,8 @@ package net.bladehunt.kotstom.serialization.namespace
 import net.minestom.server.potion.PotionEffect
 import net.minestom.server.utils.NamespaceID
 
-object PotionEffectSerializer : AbstractProtocolObjectSerializer<PotionEffect>("PotionEffect") {
+object PotionEffectSerializer :
+    AbstractProtocolObjectSerializer<PotionEffect>(PotionEffect::class) {
     override fun fromNamespaceId(namespaceID: NamespaceID): PotionEffect? =
         PotionEffect.fromNamespaceId(namespaceID)
 }

--- a/serialization/src/main/kotlin/net/bladehunt/kotstom/serialization/point/BlockVecSerializer.kt
+++ b/serialization/src/main/kotlin/net/bladehunt/kotstom/serialization/point/BlockVecSerializer.kt
@@ -1,0 +1,44 @@
+package net.bladehunt.kotstom.serialization.point
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.buildClassSerialDescriptor
+import kotlinx.serialization.descriptors.element
+import kotlinx.serialization.encoding.*
+import net.minestom.server.coordinate.BlockVec
+
+object BlockVecSerializer : KSerializer<BlockVec> {
+    override val descriptor: SerialDescriptor =
+        buildClassSerialDescriptor("Vec") {
+            element<Double>("x")
+            element<Double>("y")
+            element<Double>("z")
+        }
+
+    override fun deserialize(decoder: Decoder): BlockVec =
+        decoder.decodeStructure(descriptor) {
+            var x: Int? = null
+            var y: Int? = null
+            var z: Int? = null
+
+            while (true) {
+                when (val index = decodeElementIndex(descriptor)) {
+                    0 -> x = decodeIntElement(descriptor, 0)
+                    1 -> y = decodeIntElement(descriptor, 1)
+                    2 -> z = decodeIntElement(descriptor, 2)
+                    CompositeDecoder.DECODE_DONE -> break
+                    else -> error("Unexpected index: $index")
+                }
+            }
+
+            BlockVec(requireNotNull(x), requireNotNull(y), requireNotNull(z))
+        }
+
+    override fun serialize(encoder: Encoder, value: BlockVec) {
+        encoder.encodeStructure(descriptor) {
+            encodeIntElement(descriptor, 0, value.blockX())
+            encodeIntElement(descriptor, 1, value.blockY())
+            encodeIntElement(descriptor, 2, value.blockZ())
+        }
+    }
+}

--- a/serialization/src/main/kotlin/net/bladehunt/kotstom/serialization/point/BlockVecSerializer.kt
+++ b/serialization/src/main/kotlin/net/bladehunt/kotstom/serialization/point/BlockVecSerializer.kt
@@ -9,7 +9,7 @@ import net.minestom.server.coordinate.BlockVec
 
 object BlockVecSerializer : KSerializer<BlockVec> {
     override val descriptor: SerialDescriptor =
-        buildClassSerialDescriptor("Vec") {
+        buildClassSerialDescriptor(BlockVec::class.qualifiedName!!) {
             element<Double>("x")
             element<Double>("y")
             element<Double>("z")

--- a/serialization/src/main/kotlin/net/bladehunt/kotstom/serialization/point/BlockVecSerializer.kt
+++ b/serialization/src/main/kotlin/net/bladehunt/kotstom/serialization/point/BlockVecSerializer.kt
@@ -9,7 +9,7 @@ import net.minestom.server.coordinate.BlockVec
 
 object BlockVecSerializer : KSerializer<BlockVec> {
     override val descriptor: SerialDescriptor =
-        buildClassSerialDescriptor(BlockVec::class.qualifiedName!!) {
+        buildClassSerialDescriptor(BlockVec::class.simpleName!!) {
             element<Double>("x")
             element<Double>("y")
             element<Double>("z")

--- a/serialization/src/main/kotlin/net/bladehunt/kotstom/serialization/point/PosSerializer.kt
+++ b/serialization/src/main/kotlin/net/bladehunt/kotstom/serialization/point/PosSerializer.kt
@@ -1,0 +1,60 @@
+package net.bladehunt.kotstom.serialization.point
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.buildClassSerialDescriptor
+import kotlinx.serialization.descriptors.element
+import kotlinx.serialization.encoding.*
+import net.minestom.server.coordinate.Pos
+
+object PosSerializer : KSerializer<Pos> {
+    override val descriptor: SerialDescriptor =
+        buildClassSerialDescriptor("Pos") {
+            element<Double>("x")
+            element<Double>("y")
+            element<Double>("z")
+
+            element<Float>("yaw")
+            element<Float>("pitch")
+        }
+
+    override fun deserialize(decoder: Decoder): Pos =
+        decoder.decodeStructure(descriptor) {
+            var x: Double? = null
+            var y: Double? = null
+            var z: Double? = null
+
+            var yaw: Float? = null
+            var pitch: Float? = null
+
+            while (true) {
+                when (val index = decodeElementIndex(descriptor)) {
+                    0 -> x = decodeDoubleElement(descriptor, 0)
+                    1 -> y = decodeDoubleElement(descriptor, 1)
+                    2 -> z = decodeDoubleElement(descriptor, 2)
+                    3 -> yaw = decodeFloatElement(descriptor, 3)
+                    4 -> pitch = decodeFloatElement(descriptor, 4)
+                    CompositeDecoder.DECODE_DONE -> break
+                    else -> error("Unexpected index: $index")
+                }
+            }
+
+            Pos(
+                requireNotNull(x),
+                requireNotNull(y),
+                requireNotNull(z),
+                requireNotNull(yaw),
+                requireNotNull(pitch))
+        }
+
+    override fun serialize(encoder: Encoder, value: Pos) {
+        encoder.encodeStructure(descriptor) {
+            encodeDoubleElement(descriptor, 0, value.x)
+            encodeDoubleElement(descriptor, 1, value.y)
+            encodeDoubleElement(descriptor, 2, value.z)
+
+            encodeFloatElement(descriptor, 3, value.yaw)
+            encodeFloatElement(descriptor, 4, value.pitch)
+        }
+    }
+}

--- a/serialization/src/main/kotlin/net/bladehunt/kotstom/serialization/point/PosSerializer.kt
+++ b/serialization/src/main/kotlin/net/bladehunt/kotstom/serialization/point/PosSerializer.kt
@@ -9,7 +9,7 @@ import net.minestom.server.coordinate.Pos
 
 object PosSerializer : KSerializer<Pos> {
     override val descriptor: SerialDescriptor =
-        buildClassSerialDescriptor("Pos") {
+        buildClassSerialDescriptor(Pos::class.qualifiedName!!) {
             element<Double>("x")
             element<Double>("y")
             element<Double>("z")

--- a/serialization/src/main/kotlin/net/bladehunt/kotstom/serialization/point/PosSerializer.kt
+++ b/serialization/src/main/kotlin/net/bladehunt/kotstom/serialization/point/PosSerializer.kt
@@ -9,7 +9,7 @@ import net.minestom.server.coordinate.Pos
 
 object PosSerializer : KSerializer<Pos> {
     override val descriptor: SerialDescriptor =
-        buildClassSerialDescriptor(Pos::class.qualifiedName!!) {
+        buildClassSerialDescriptor(Pos::class.simpleName!!) {
             element<Double>("x")
             element<Double>("y")
             element<Double>("z")

--- a/serialization/src/main/kotlin/net/bladehunt/kotstom/serialization/point/VecSerializer.kt
+++ b/serialization/src/main/kotlin/net/bladehunt/kotstom/serialization/point/VecSerializer.kt
@@ -9,7 +9,7 @@ import net.minestom.server.coordinate.Vec
 
 object VecSerializer : KSerializer<Vec> {
     override val descriptor: SerialDescriptor =
-        buildClassSerialDescriptor(Vec::class.qualifiedName!!) {
+        buildClassSerialDescriptor(Vec::class.simpleName!!) {
             element<Double>("x")
             element<Double>("y")
             element<Double>("z")

--- a/serialization/src/main/kotlin/net/bladehunt/kotstom/serialization/point/VecSerializer.kt
+++ b/serialization/src/main/kotlin/net/bladehunt/kotstom/serialization/point/VecSerializer.kt
@@ -9,7 +9,7 @@ import net.minestom.server.coordinate.Vec
 
 object VecSerializer : KSerializer<Vec> {
     override val descriptor: SerialDescriptor =
-        buildClassSerialDescriptor("Vec") {
+        buildClassSerialDescriptor(Vec::class.qualifiedName!!) {
             element<Double>("x")
             element<Double>("y")
             element<Double>("z")

--- a/serialization/src/main/kotlin/net/bladehunt/kotstom/serialization/point/VecSerializer.kt
+++ b/serialization/src/main/kotlin/net/bladehunt/kotstom/serialization/point/VecSerializer.kt
@@ -1,0 +1,44 @@
+package net.bladehunt.kotstom.serialization.point
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.buildClassSerialDescriptor
+import kotlinx.serialization.descriptors.element
+import kotlinx.serialization.encoding.*
+import net.minestom.server.coordinate.Vec
+
+object VecSerializer : KSerializer<Vec> {
+    override val descriptor: SerialDescriptor =
+        buildClassSerialDescriptor("Vec") {
+            element<Double>("x")
+            element<Double>("y")
+            element<Double>("z")
+        }
+
+    override fun deserialize(decoder: Decoder): Vec =
+        decoder.decodeStructure(descriptor) {
+            var x: Double? = null
+            var y: Double? = null
+            var z: Double? = null
+
+            while (true) {
+                when (val index = decodeElementIndex(descriptor)) {
+                    0 -> x = decodeDoubleElement(descriptor, 0)
+                    1 -> y = decodeDoubleElement(descriptor, 1)
+                    2 -> z = decodeDoubleElement(descriptor, 2)
+                    CompositeDecoder.DECODE_DONE -> break
+                    else -> error("Unexpected index: $index")
+                }
+            }
+
+            Vec(requireNotNull(x), requireNotNull(y), requireNotNull(z))
+        }
+
+    override fun serialize(encoder: Encoder, value: Vec) {
+        encoder.encodeStructure(descriptor) {
+            encodeDoubleElement(descriptor, 0, value.x)
+            encodeDoubleElement(descriptor, 1, value.y)
+            encodeDoubleElement(descriptor, 2, value.z)
+        }
+    }
+}

--- a/serialization/src/main/kotlin/net/bladehunt/kotstom/serialization/uuid/StringUuidSerializer.kt
+++ b/serialization/src/main/kotlin/net/bladehunt/kotstom/serialization/uuid/StringUuidSerializer.kt
@@ -1,0 +1,18 @@
+package net.bladehunt.kotstom.serialization.uuid
+
+import java.util.UUID
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+object StringUuidSerializer : KSerializer<UUID> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("UUID", PrimitiveKind.STRING)
+
+    override fun deserialize(decoder: Decoder): UUID = UUID.fromString(decoder.decodeString())
+
+    override fun serialize(encoder: Encoder, value: UUID) = encoder.encodeString(value.toString())
+}

--- a/serialization/src/main/kotlin/net/bladehunt/kotstom/serialization/uuid/StringUuidSerializer.kt
+++ b/serialization/src/main/kotlin/net/bladehunt/kotstom/serialization/uuid/StringUuidSerializer.kt
@@ -10,7 +10,7 @@ import kotlinx.serialization.encoding.Encoder
 
 object StringUuidSerializer : KSerializer<UUID> {
     override val descriptor: SerialDescriptor =
-        PrimitiveSerialDescriptor("UUID", PrimitiveKind.STRING)
+        PrimitiveSerialDescriptor(UUID::class.qualifiedName!!, PrimitiveKind.STRING)
 
     override fun deserialize(decoder: Decoder): UUID = UUID.fromString(decoder.decodeString())
 

--- a/serialization/src/main/kotlin/net/bladehunt/kotstom/serialization/uuid/UuidSerializer.kt
+++ b/serialization/src/main/kotlin/net/bladehunt/kotstom/serialization/uuid/UuidSerializer.kt
@@ -1,15 +1,15 @@
 package net.bladehunt.kotstom.serialization.uuid
 
-import java.util.*
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.descriptors.buildClassSerialDescriptor
 import kotlinx.serialization.descriptors.element
 import kotlinx.serialization.encoding.*
+import java.util.*
 
 object UuidSerializer : KSerializer<UUID> {
     override val descriptor: SerialDescriptor =
-        buildClassSerialDescriptor("UUID") {
+        buildClassSerialDescriptor(UUID::class.qualifiedName!!) {
             element<Long>("leastSignificantBits")
             element<Long>("mostSignificantBits")
         }

--- a/serialization/src/main/kotlin/net/bladehunt/kotstom/serialization/uuid/UuidSerializer.kt
+++ b/serialization/src/main/kotlin/net/bladehunt/kotstom/serialization/uuid/UuidSerializer.kt
@@ -1,0 +1,40 @@
+package net.bladehunt.kotstom.serialization.uuid
+
+import java.util.*
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.buildClassSerialDescriptor
+import kotlinx.serialization.descriptors.element
+import kotlinx.serialization.encoding.*
+
+object UuidSerializer : KSerializer<UUID> {
+    override val descriptor: SerialDescriptor =
+        buildClassSerialDescriptor("UUID") {
+            element<Long>("leastSignificantBits")
+            element<Long>("mostSignificantBits")
+        }
+
+    override fun deserialize(decoder: Decoder): UUID =
+        decoder.decodeStructure(descriptor) {
+            var leastSignificantBits: Long = 0
+            var mostSignificantBits: Long = 0
+
+            while (true) {
+                when (val index = decodeElementIndex(descriptor)) {
+                    0 -> leastSignificantBits = decodeLongElement(descriptor, 0)
+                    1 -> mostSignificantBits = decodeLongElement(descriptor, 1)
+                    CompositeDecoder.DECODE_DONE -> break
+                    else -> error("Unexpected index: $index")
+                }
+            }
+
+            UUID(mostSignificantBits, leastSignificantBits)
+        }
+
+    override fun serialize(encoder: Encoder, value: UUID) {
+        encoder.encodeStructure(descriptor) {
+            encodeLongElement(descriptor, 0, value.leastSignificantBits)
+            encodeLongElement(descriptor, 1, value.mostSignificantBits)
+        }
+    }
+}

--- a/serialization/src/test/kotlin/net/bladehunt/kotstom/Json.kt
+++ b/serialization/src/test/kotlin/net/bladehunt/kotstom/Json.kt
@@ -1,0 +1,6 @@
+package net.bladehunt.kotstom
+
+import kotlinx.serialization.json.Json
+import net.bladehunt.kotstom.serialization.MinestomModule
+
+val Json = Json { serializersModule = MinestomModule }

--- a/serialization/src/test/kotlin/net/bladehunt/kotstom/PointTest.kt
+++ b/serialization/src/test/kotlin/net/bladehunt/kotstom/PointTest.kt
@@ -1,0 +1,25 @@
+package net.bladehunt.kotstom
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import net.minestom.server.coordinate.Point
+import net.minestom.server.coordinate.Pos
+
+class PointTest :
+    FunSpec({
+        test("pos should not have a type field without polymorphism") {
+            val pos = Pos(0.5, 1.5, 0.5, 45f, 108f)
+
+            Json.encodeToJsonElement(pos).jsonObject.contains("type") shouldNotBe true
+        }
+        test("pos should be the same with polymorphism") {
+            val point: Point = Pos(0.5, 1.5, 0.5, 45f, 108f)
+
+            Json.encodeToJsonElement(point).jsonObject["type"]!!.jsonPrimitive.content shouldBe
+                Pos::class.simpleName
+        }
+    })

--- a/serialization/src/test/kotlin/net/bladehunt/kotstom/SerializationTest.kt
+++ b/serialization/src/test/kotlin/net/bladehunt/kotstom/SerializationTest.kt
@@ -1,0 +1,30 @@
+package net.bladehunt.kotstom
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.encodeToString
+import net.minestom.server.entity.EntityType
+import net.minestom.server.item.Material
+import net.minestom.server.potion.PotionEffect
+
+class SerializationTest :
+    FunSpec({
+        test("materials should serialize their namespace ID") {
+            val material = Material.STONE
+            val encoded = Json.encodeToString(material)
+
+            material shouldBe Json.decodeFromString<Material>(encoded)
+        }
+        test("potions should serialize their namespace ID") {
+            val potion = PotionEffect.HUNGER
+            val encoded = Json.encodeToString(potion)
+
+            potion shouldBe Json.decodeFromString<PotionEffect>(encoded)
+        }
+        test("entity types should serialize their namespace ID") {
+            val entityType = EntityType.CAT
+            val encoded = Json.encodeToString(entityType)
+
+            entityType shouldBe Json.decodeFromString<EntityType>(encoded)
+        }
+    })

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -5,10 +5,8 @@ pluginManagement {
     }
 }
 
-plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
-}
+plugins { id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0" }
 
 rootProject.name = "KotStom"
-include("example")
-include("adventure-serialization")
+
+include("example", "adventure-serialization", "serialization")


### PR DESCRIPTION
This PR adds a module for basic serializers for things such as Material, PotionEffect, MiniMessage Components, UUIDs, Points (allows polymorphic).

Version bumped to 0.3.0-alpha.2