### PR TITLE
Better tag delegation

### DIFF
--- a/example/src/main/kotlin/net/bladehunt/kotstom/example/TagDelegates.kt
+++ b/example/src/main/kotlin/net/bladehunt/kotstom/example/TagDelegates.kt
@@ -1,0 +1,15 @@
+package net.bladehunt.kotstom.example
+
+import net.bladehunt.kotstom.extension.getValue
+import net.bladehunt.kotstom.extension.lazy
+import net.bladehunt.kotstom.extension.orElse
+import net.bladehunt.kotstom.extension.setValue
+import net.minestom.server.entity.Player
+import net.minestom.server.item.ItemStack
+import net.minestom.server.tag.Tag
+
+var Player.myValue: String? by Tag.String("myValue")
+
+var Player.myLazyValue: String by Tag.String("myValue").lazy { "default" }
+
+val ItemStack.myDefaultValue: String by Tag.String("myValue").orElse { "default" }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 kotlin.code.style=official
 name=kotstom
 group=net.bladehunt
-version=0.4.0-alpha.3
+version=0.4.0-alpha.4

--- a/src/main/kotlin/net/bladehunt/kotstom/TagDelegates.kt
+++ b/src/main/kotlin/net/bladehunt/kotstom/TagDelegates.kt
@@ -1,0 +1,32 @@
+package net.bladehunt.kotstom
+
+import net.minestom.server.tag.Tag
+import net.minestom.server.tag.TagReadable
+import net.minestom.server.tag.TagWritable
+import kotlin.reflect.KProperty
+
+class DefaultTagDelegate<T : TagReadable, V>(
+    val tag: Tag<V>,
+    val default: (T) -> V
+) {
+    operator fun getValue(thisRef: T, property: KProperty<*>): V =
+        if (thisRef.hasTag(tag)) thisRef.getTag(tag)
+        else default(thisRef)
+
+    operator fun setValue(thisRef: TagWritable, property: KProperty<*>, value: V) {
+        thisRef.setTag(tag, value)
+    }
+}
+
+class LazyTagDelegate<T : TagWritable, V>(
+    val tag: Tag<V>,
+    val default: (T) -> V
+) {
+    operator fun getValue(thisRef: T, property: KProperty<*>): V =
+        if (thisRef.hasTag(tag)) thisRef.getTag(tag)
+        else default(thisRef).also { thisRef.setTag(tag, it) }
+
+    operator fun setValue(thisRef: T, property: KProperty<*>, value: V) {
+        thisRef.setTag(tag, value)
+    }
+}

--- a/src/main/kotlin/net/bladehunt/kotstom/extension/TagExt.kt
+++ b/src/main/kotlin/net/bladehunt/kotstom/extension/TagExt.kt
@@ -1,9 +1,11 @@
 package net.bladehunt.kotstom.extension
 
-import kotlin.reflect.KProperty
+import net.bladehunt.kotstom.DefaultTagDelegate
+import net.bladehunt.kotstom.LazyTagDelegate
 import net.minestom.server.tag.Tag
 import net.minestom.server.tag.TagReadable
 import net.minestom.server.tag.TagWritable
+import kotlin.reflect.KProperty
 
 /**
  * Delegation utility for getting the value of a tag
@@ -22,3 +24,20 @@ operator fun <T> Tag<T>.getValue(thisRef: TagReadable?, property: KProperty<*>):
 operator fun <T> Tag<T>.setValue(thisRef: TagWritable?, property: KProperty<*>, value: T) {
     thisRef?.setTag(this, value)
 }
+
+/**
+ * Tag delegate that lazily sets a default value on a TagWritable if it doesn't exist.
+ * Otherwise, returns the tag value.
+ *
+ * @author oglassdev
+ */
+fun <W : TagWritable, T> Tag<T>.lazy(block: (W) -> T): LazyTagDelegate<W, T> =
+    LazyTagDelegate(this, block)
+
+/**
+ * Tag delegate that returns a default if the TagReadable doesn't contain the tag.
+ *
+ * @author oglassdev
+ */
+fun <W : TagReadable, T> Tag<T>.orElse(default: (W) -> T): DefaultTagDelegate<W, T> =
+    DefaultTagDelegate(this, default)


### PR DESCRIPTION
Features
- Tag#lazy: lazily sets the value of the evaluated expression to the TagWritable when first accessed if it doesn't exist; otherwise returns the value
- Tag#orElse: evaluates the expression and returns the value if the TagReadable doesn't contain the value - otherwise returns the value; allows setting if it is a TagWritiable